### PR TITLE
Unbind when index of callback is 0

### DIFF
--- a/build/bin/pusher-test-stub.js
+++ b/build/bin/pusher-test-stub.js
@@ -143,7 +143,7 @@ Example:
 
   EventsDispatcher.prototype.unbind = function(event_name, callback) {
     callbackIndex = this.callbacks[event_name] && this.callbacks[event_name].indexOf(callback);
-    if (callbackIndex)
+    if ((callbackIndex != undefined) && (callBackIndex > -1))
       this.callbacks[event_name].splice(callbackIndex, 1);
     return this;// chainable
   };

--- a/libs/libs.js
+++ b/libs/libs.js
@@ -143,7 +143,7 @@ Example:
 
   EventsDispatcher.prototype.unbind = function(event_name, callback) {
     callbackIndex = this.callbacks[event_name] && this.callbacks[event_name].indexOf(callback);
-    if (callbackIndex)
+    if ((callbackIndex != undefined) && (callBackIndex > -1))
       this.callbacks[event_name].splice(callbackIndex, 1);
     return this;// chainable
   };


### PR DESCRIPTION
Addreses https://github.com/leggetter/pusher-test-stub/issues/5

This adds the correct condition to check if the given callback is bound to the event.
