### PR TITLE
Use callbackIndex instead of callBackIndex

### DIFF
--- a/build/bin/pusher-test-stub.js
+++ b/build/bin/pusher-test-stub.js
@@ -143,7 +143,7 @@ Example:
 
   EventsDispatcher.prototype.unbind = function(event_name, callback) {
     callbackIndex = this.callbacks[event_name] && this.callbacks[event_name].indexOf(callback);
-    if ((callbackIndex != undefined) && (callBackIndex > -1))
+    if ((callbackIndex != undefined) && (callbackIndex > -1))
       this.callbacks[event_name].splice(callbackIndex, 1);
     return this;// chainable
   };

--- a/libs/libs.js
+++ b/libs/libs.js
@@ -143,7 +143,7 @@ Example:
 
   EventsDispatcher.prototype.unbind = function(event_name, callback) {
     callbackIndex = this.callbacks[event_name] && this.callbacks[event_name].indexOf(callback);
-    if ((callbackIndex != undefined) && (callBackIndex > -1))
+    if ((callbackIndex != undefined) && (callbackIndex > -1))
       this.callbacks[event_name].splice(callbackIndex, 1);
     return this;// chainable
   };


### PR DESCRIPTION
I get this error:

```
ReferenceError: Can't find variable: callBackIndex
```

Follow-up to https://github.com/leggetter/pusher-test-stub/pull/6.

Sorry for the mistake. It should work now. :bow:
